### PR TITLE
Ignore personal CSV data and .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Personal financial data / OS noise
+*.csv
+.DS_Store


### PR DESCRIPTION
## What

Add ignore rules to `.gitignore` so personal financial exports and macOS metadata are never accidentally committed to this public repo:

- `*.csv` — the working directory accumulates HSA/account transaction CSVs (filenames contain account numbers). These are personal data and must stay out of version control.
- `.DS_Store` — macOS Finder noise.

## Why

The repo currently uses the stock Python `.gitignore`, which does not cover CSVs. Local exports were showing up as untracked, one `git add .` away from leaking account-level financial data.

## Notes

No code changes; documentation/data-hygiene only. Existing local CSVs remain on disk but are now git-ignored (verified via `git check-ignore`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)